### PR TITLE
Webpack 2 support and use loader to skip AMD

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "Rafael Xavier de Souza @rxaviers",
   "license": "MIT",
   "peerDependencies": {
-    "webpack": "^1.9.0"
+    "imports-loader": "^0.7.0",
+    "webpack": "^1.9.0 || ^2.2.0-rc"
   },
   "devDependencies": {
     "jshint": "2.6.x"


### PR DESCRIPTION
This commit adds support for Webpack 2. It also changes the logic from custom code to skip AMD loading to use the standard functionality of webpacks imports-loader.

Fixes: #1 