### PR TITLE
skip entry AMD check if no regex is supplied

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,9 @@ SkipAMDPlugin.prototype.apply = function(compiler) {
             const defineAMD = source.source().search(/define\.amd/);
             const newSource = new ReplaceSource(source);
             
-            return newSource.replace(defineAMD, defineAMD + 9, 'false');
+            newSource.replace(defineAMD, defineAMD + 9, 'false');
+
+            return newSource;
           });
         }
       });

--- a/index.js
+++ b/index.js
@@ -39,18 +39,18 @@ SkipAMDPlugin.prototype.apply = function(compiler) {
   // Hack to support webpack 1.x and 2.x.
   // webpack 2.x
   if (NormalModuleFactory.prototype.createParser) {
-    if (this.requestRegExp) {
       compiler.plugin("compilation", function(compilation, params) {
-        params.normalModuleFactory.plugin("parser", run);
+        if (this.requestRegExp) {
+          params.normalModuleFactory.plugin("parser", run);
+        } else {
+          compilation.templatesPlugin("render-with-entry", function(source) {
+            const defineAMD = source.source().search(/define\.amd/);
+            const newSource = new ReplaceSource(source);
+            
+            return newSource.replace(defineAMD, defineAMD + 9, 'false');
+          });
+        }
       });
-    } else {
-      compilation.templatesPlugin("render-with-entry", function(source) {
-        const defineAMD = source.source().search(/define\.amd/);
-        const newSource = new ReplaceSource(source);
-        
-        return newSource.replace(defineAMD, defineAMD + 9, 'false');
-      });
-    }
 
   // webpack 1.x
   } else {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "Rafael Xavier de Souza @rxaviers",
   "license": "MIT",
   "peerDependencies": {
-    "webpack": "^1.9.0 || ^2.2.0 || ^3.0.0"
+    "webpack": "^1.9.0 || ^2.2.0 || ^3.0.0",
+    "webpack-sources": "*"
   },
   "devDependencies": {
     "jshint": "2.6.x"


### PR DESCRIPTION
made these changes because we need to disable AMD on a DLL bundle which requires fiddling with the actual webpack entry that is appended to the bundle rather than our code. There's probably a nicer way to do this, it's my first time getting in to webpack like this, but it seems to work for me.